### PR TITLE
Supporting automatic timestamp functionality of TS.ADD

### DIFF
--- a/redistimeseries/src/main/java/io/github/dengliming/redismodule/redistimeseries/RedisTimeSeries.java
+++ b/redistimeseries/src/main/java/io/github/dengliming/redismodule/redistimeseries/RedisTimeSeries.java
@@ -106,7 +106,7 @@ public class RedisTimeSeries {
 
         List<Object> args = new ArrayList<>();
         args.add(sample.getKey());
-        args.add(sample.getValue().getTimestamp());
+        args.add(sample.getValue().getTimestamp() > 0 ? sample.getValue().getTimestamp() : "*");
         args.add(sample.getValue().getValue());
         if (options != null) {
             options.isAdd(true).build(args);


### PR DESCRIPTION
Supporting functionality of TS.ADD from RedisTimeseries Documentation of commands
TS.ADD: use * for automatic timestamp (using the system clock)